### PR TITLE
LinuxでのMDC更新コマンド（mdc update）の実装

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"mdc/internal/logger"
+	"mdc/internal/updater"
+	"mdc/internal/version"
+
+	"github.com/spf13/cobra"
+)
+
+var updateFunc = updater.Update
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update mdc to the latest release from GitHub",
+	Long:  "Download the latest Linux amd64 binary from GitHub Releases and replace the running executable.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runUpdate(); err != nil {
+			logger.Error("update", "mdc update", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+}
+
+// runUpdate performs the update and prints the outcome. It returns any error
+// so the caller (or tests) can handle it; user-facing output goes through
+// logger.
+func runUpdate() error {
+	result, err := updateFunc(updater.Options{})
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case !result.Skipped:
+		logger.Info("update", fmt.Sprintf("updated to %s", result.Version))
+	case result.LocalNewer:
+		logger.Info("update", fmt.Sprintf("local version v%s is ahead of the latest release %s",
+			updater.DisplayVersion(version.Version), result.Version))
+	default:
+		logger.Info("update", fmt.Sprintf("already up to date (%s)", result.Version))
+	}
+	return nil
+}
+
+// setUpdateFunc replaces the update implementation for tests.
+func setUpdateFunc(fn func(updater.Options) (updater.Result, error)) {
+	updateFunc = fn
+}
+
+// resetUpdateFunc restores the default update implementation.
+func resetUpdateFunc() {
+	updateFunc = updater.Update
+}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"mdc/internal/logger"
+	"mdc/internal/updater"
+)
+
+func TestUpdateCommandRegistered(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"update"})
+	if err != nil {
+		t.Fatalf("rootCmd.Find(update) error = %v", err)
+	}
+	if cmd.Use != "update" {
+		t.Fatalf("command Use = %q, want update", cmd.Use)
+	}
+}
+
+func TestRunUpdateWithStub(t *testing.T) {
+	t.Run("returns nil on successful update", func(t *testing.T) {
+		setUpdateFunc(func(opts updater.Options) (updater.Result, error) {
+			return updater.Result{Skipped: false, Version: "v2.0.4"}, nil
+		})
+		t.Cleanup(resetUpdateFunc)
+
+		if err := runUpdate(); err != nil {
+			t.Fatalf("runUpdate() error = %v", err)
+		}
+	})
+
+	t.Run("returns nil when already up to date", func(t *testing.T) {
+		setUpdateFunc(func(opts updater.Options) (updater.Result, error) {
+			return updater.Result{Skipped: true, Version: "v2.0.3"}, nil
+		})
+		t.Cleanup(resetUpdateFunc)
+
+		if err := runUpdate(); err != nil {
+			t.Fatalf("runUpdate() error = %v", err)
+		}
+	})
+
+	t.Run("returns error from updater", func(t *testing.T) {
+		setUpdateFunc(func(opts updater.Options) (updater.Result, error) {
+			return updater.Result{}, errors.New("update failed")
+		})
+		t.Cleanup(resetUpdateFunc)
+
+		err := runUpdate()
+		if err == nil {
+			t.Fatal("runUpdate() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "update failed") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}
+
+func TestRunUpdateMessages(t *testing.T) {
+	cases := []struct {
+		name   string
+		result updater.Result
+		want   string
+	}{
+		{
+			name:   "updated reports the new release tag",
+			result: updater.Result{Skipped: false, Version: "v2.0.4"},
+			want:   "updated to v2.0.4",
+		},
+		{
+			name:   "up to date prints the latest release tag",
+			result: updater.Result{Skipped: true, Version: "v2.0.3"},
+			want:   "already up to date (v2.0.3)",
+		},
+		{
+			name:   "local newer reports being ahead of the latest release",
+			result: updater.Result{Skipped: true, LocalNewer: true, Version: "v2.0.3"},
+			want:   "ahead of the latest release v2.0.3",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setUpdateFunc(func(opts updater.Options) (updater.Result, error) {
+				return tc.result, nil
+			})
+			t.Cleanup(resetUpdateFunc)
+
+			var buf bytes.Buffer
+			logger.SetOutput(&buf)
+			t.Cleanup(func() { logger.SetOutput(os.Stdout) })
+
+			if err := runUpdate(); err != nil {
+				t.Fatalf("runUpdate() error = %v", err)
+			}
+			if !strings.Contains(buf.String(), tc.want) {
+				t.Fatalf("output = %q, want substring %q", buf.String(), tc.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,19 @@ module mdc
 go 1.25.0
 
 require (
+	github.com/creack/pty/v2 v2.0.1
 	github.com/jedib0t/go-pretty/v6 v6.7.8
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/mod v0.24.0
+	golang.org/x/term v0.40.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
-	github.com/creack/pty/v2 v2.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.41.0 // indirect
-	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
-golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -118,6 +118,13 @@ func Error(projectName, cmd string, err error) {
 	writef("❌ [%s] Failed: %s — %s\n", prefix(projectName), colorCmd(cmd), err)
 }
 
+// Info prints a plain status line under a project prefix. Unlike Success it
+// does not apply command styling, so it suits human-readable messages
+// (e.g. "already up to date") rather than shell commands.
+func Info(projectName, msg string) {
+	writef("✅ [%s] %s\n", prefix(projectName), msg)
+}
+
 func Background(projectName, cmd string, pid int) {
 	writef("🔄 [%s] Background: %s (PID: %s)\n", prefix(projectName), colorCmd(cmd), colorPID(pid))
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -97,6 +97,28 @@ func TestError(t *testing.T) {
 	}
 }
 
+func TestInfo(t *testing.T) {
+	msg := "already up to date (v2.0.3)"
+	out := captureOutput(t, func() {
+		Info("update", msg)
+	})
+	plain := stripANSI(out)
+	if !strings.Contains(plain, "[update]") {
+		t.Errorf("output missing project prefix: %q", plain)
+	}
+	if !strings.Contains(plain, msg) {
+		t.Errorf("output missing message: %q", plain)
+	}
+	if !strings.Contains(out, "✅") {
+		t.Errorf("output missing emoji: %q", out)
+	}
+	// Info must NOT style the message as a shell command (unlike Success):
+	// the cyan colorCmd wrapping must be absent.
+	if strings.Contains(out, text.Colors{text.FgCyan}.Sprint(msg)) {
+		t.Errorf("Info should not color the message as a command: %q", out)
+	}
+}
+
 func TestBackground(t *testing.T) {
 	out := captureOutput(t, func() {
 		Background("api", "make run", 12345)

--- a/internal/updater/constants.go
+++ b/internal/updater/constants.go
@@ -1,0 +1,29 @@
+package updater
+
+import "fmt"
+
+const (
+	githubOwner = "tominaga-h"
+	githubRepo  = "multi-docker-commander"
+
+	defaultAPIBaseURL = "https://api.github.com"
+
+	platformOS   = "linux"
+	platformArch = "amd64"
+)
+
+func latestReleaseAPIPath() string {
+	return fmt.Sprintf("/repos/%s/%s/releases/latest", githubOwner, githubRepo)
+}
+
+// assetBinaryName / assetChecksumName must stay in lockstep with the release
+// asset naming in .github/workflows/release.yml (BIN_NAME = mdc-<ver>-<goos>-<goarch>,
+// checksum = <BIN_NAME>.sha256), which is the source of truth. If that workflow
+// changes the pattern, update these or `mdc update` will fail to match any asset.
+func assetBinaryName(tag string) string {
+	return fmt.Sprintf("mdc-%s-%s-%s", tag, platformOS, platformArch)
+}
+
+func assetChecksumName(binaryName string) string {
+	return binaryName + ".sha256"
+}

--- a/internal/updater/download.go
+++ b/internal/updater/download.go
@@ -1,0 +1,99 @@
+package updater
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+func downloadAndVerify(client *http.Client, urls *assetURLs) ([]byte, error) {
+	if client == nil {
+		return nil, fmt.Errorf("http client is required")
+	}
+	if urls == nil {
+		return nil, fmt.Errorf("asset URLs are required")
+	}
+
+	// The binary and checksum are independent GETs; fetch them concurrently
+	// so the small checksum round-trip overlaps the large binary download.
+	var (
+		binaryData, checksumData []byte
+		binaryErr, checksumErr   error
+		wg                       sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		binaryData, binaryErr = downloadBytes(client, urls.BinaryURL)
+	}()
+	go func() {
+		defer wg.Done()
+		checksumData, checksumErr = downloadBytes(client, urls.ChecksumURL)
+	}()
+	wg.Wait()
+
+	if binaryErr != nil {
+		return nil, fmt.Errorf("download binary: %w", binaryErr)
+	}
+	if checksumErr != nil {
+		return nil, fmt.Errorf("download checksum: %w", checksumErr)
+	}
+
+	expectedHash, err := parseChecksumFile(string(checksumData), urls.BinaryName)
+	if err != nil {
+		return nil, fmt.Errorf("parse checksum file: %w", err)
+	}
+
+	actualHash := sha256.Sum256(binaryData)
+	actualHex := hex.EncodeToString(actualHash[:])
+	if !strings.EqualFold(actualHex, expectedHash) {
+		return nil, fmt.Errorf("checksum mismatch: expected %s, got %s", expectedHash, actualHex)
+	}
+
+	return binaryData, nil
+}
+
+func downloadBytes(client *http.Client, url string) ([]byte, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("status %d: read body: %w", resp.StatusCode, readErr)
+		}
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func parseChecksumFile(content, binaryName string) (string, error) {
+	lines := strings.Split(strings.TrimSpace(content), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		name := strings.TrimPrefix(fields[1], "*")
+		if name == binaryName {
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("checksum for %q not found in checksum file", binaryName)
+}

--- a/internal/updater/download_test.go
+++ b/internal/updater/download_test.go
@@ -1,0 +1,141 @@
+package updater
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDownloadAndVerify(t *testing.T) {
+	binaryName := assetBinaryName("v2.0.3")
+	binaryData := []byte("fake-binary-content")
+	hash := sha256.Sum256(binaryData)
+	checksumContent := fmt.Sprintf("%s  %s\n", hex.EncodeToString(hash[:]), binaryName)
+
+	urls := &assetURLs{
+		BinaryURL:   "/binary",
+		ChecksumURL: "/checksum",
+		BinaryName:  binaryName,
+	}
+
+	t.Run("verifies matching checksum", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/binary":
+				_, _ = w.Write(binaryData)
+			case "/checksum":
+				_, _ = w.Write([]byte(checksumContent))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		urlsWithHost := *urls
+		urlsWithHost.BinaryURL = server.URL + "/binary"
+		urlsWithHost.ChecksumURL = server.URL + "/checksum"
+
+		got, err := downloadAndVerify(server.Client(), &urlsWithHost)
+		if err != nil {
+			t.Fatalf("downloadAndVerify() error = %v", err)
+		}
+		if string(got) != string(binaryData) {
+			t.Fatalf("binary data mismatch")
+		}
+	})
+
+	t.Run("returns error when binary download fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/binary":
+				http.Error(w, "not found", http.StatusNotFound)
+			case "/checksum":
+				_, _ = w.Write([]byte(checksumContent))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		urlsWithHost := *urls
+		urlsWithHost.BinaryURL = server.URL + "/binary"
+		urlsWithHost.ChecksumURL = server.URL + "/checksum"
+
+		_, err := downloadAndVerify(server.Client(), &urlsWithHost)
+		if err == nil {
+			t.Fatal("downloadAndVerify() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "download binary") {
+			t.Fatalf("error = %v, want download binary failure", err)
+		}
+	})
+
+	t.Run("returns error when checksum download fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/binary":
+				_, _ = w.Write(binaryData)
+			case "/checksum":
+				http.Error(w, "internal error", http.StatusInternalServerError)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		urlsWithHost := *urls
+		urlsWithHost.BinaryURL = server.URL + "/binary"
+		urlsWithHost.ChecksumURL = server.URL + "/checksum"
+
+		_, err := downloadAndVerify(server.Client(), &urlsWithHost)
+		if err == nil {
+			t.Fatal("downloadAndVerify() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "download checksum") {
+			t.Fatalf("error = %v, want download checksum failure", err)
+		}
+	})
+
+	t.Run("returns error on checksum mismatch", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/binary":
+				_, _ = w.Write(binaryData)
+			case "/checksum":
+				_, _ = w.Write([]byte("deadbeef  " + binaryName + "\n"))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		urlsWithHost := *urls
+		urlsWithHost.BinaryURL = server.URL + "/binary"
+		urlsWithHost.ChecksumURL = server.URL + "/checksum"
+
+		_, err := downloadAndVerify(server.Client(), &urlsWithHost)
+		if err == nil {
+			t.Fatal("downloadAndVerify() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "checksum mismatch") {
+			t.Fatalf("error = %v, want checksum mismatch", err)
+		}
+	})
+}
+
+func TestParseChecksumFile(t *testing.T) {
+	binaryName := "mdc-v2.0.3-linux-amd64"
+	content := "abc123  " + binaryName + "\n"
+
+	got, err := parseChecksumFile(content, binaryName)
+	if err != nil {
+		t.Fatalf("parseChecksumFile() error = %v", err)
+	}
+	if got != "abc123" {
+		t.Fatalf("hash = %q, want abc123", got)
+	}
+}

--- a/internal/updater/release.go
+++ b/internal/updater/release.go
@@ -1,0 +1,62 @@
+package updater
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func fetchLatestRelease(client *http.Client, apiBaseURL string) (*release, error) {
+	if client == nil {
+		return nil, fmt.Errorf("http client is required")
+	}
+	base := strings.TrimRight(apiBaseURL, "/")
+	url := base + latestReleaseAPIPath()
+
+	body, err := downloadBytes(client, url)
+	if err != nil {
+		return nil, fmt.Errorf("fetch latest release: %w", err)
+	}
+
+	var release release
+	if err := json.Unmarshal(body, &release); err != nil {
+		return nil, fmt.Errorf("decode release response: %w", err)
+	}
+	if err := validateTagName(release.TagName); err != nil {
+		return nil, err
+	}
+	return &release, nil
+}
+
+func resolveAssetURL(release *release) (*assetURLs, error) {
+	if release == nil {
+		return nil, fmt.Errorf("release is required")
+	}
+
+	binaryName := assetBinaryName(release.TagName)
+	checksumName := assetChecksumName(binaryName)
+
+	var binaryURL, checksumURL string
+	for _, asset := range release.Assets {
+		switch asset.Name {
+		case binaryName:
+			binaryURL = asset.BrowserDownloadURL
+		case checksumName:
+			checksumURL = asset.BrowserDownloadURL
+		}
+	}
+
+	if binaryURL == "" {
+		return nil, fmt.Errorf("binary asset %q not found in release %s", binaryName, release.TagName)
+	}
+	if checksumURL == "" {
+		return nil, fmt.Errorf("checksum asset %q not found in release %s", checksumName, release.TagName)
+	}
+
+	return &assetURLs{
+		BinaryURL:   binaryURL,
+		ChecksumURL: checksumURL,
+		BinaryName:  binaryName,
+	}, nil
+}

--- a/internal/updater/release_test.go
+++ b/internal/updater/release_test.go
@@ -1,0 +1,108 @@
+package updater
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFetchLatestRelease(t *testing.T) {
+	t.Run("returns release on success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != latestReleaseAPIPath() {
+				t.Fatalf("unexpected path: %s", r.URL.Path)
+			}
+			_ = json.NewEncoder(w).Encode(release{
+				TagName: "v2.0.4",
+				Assets:  []asset{{Name: assetBinaryName("v2.0.4"), BrowserDownloadURL: "http://example/binary"}},
+			})
+		}))
+		defer server.Close()
+
+		got, err := fetchLatestRelease(server.Client(), server.URL)
+		if err != nil {
+			t.Fatalf("fetchLatestRelease() error = %v", err)
+		}
+		if got.TagName != "v2.0.4" {
+			t.Fatalf("TagName = %q, want v2.0.4", got.TagName)
+		}
+	})
+
+	t.Run("returns error on API failure", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "not found", http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		_, err := fetchLatestRelease(server.Client(), server.URL)
+		if err == nil {
+			t.Fatal("fetchLatestRelease() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "404") {
+			t.Fatalf("error = %v, want status 404 mention", err)
+		}
+	})
+}
+
+func TestResolveAssetURL(t *testing.T) {
+	tag := "v2.0.3"
+	binaryName := assetBinaryName(tag)
+	checksumName := assetChecksumName(binaryName)
+
+	t.Run("resolves binary and checksum URLs", func(t *testing.T) {
+		rel := &release{
+			TagName: tag,
+			Assets: []asset{
+				{Name: binaryName, BrowserDownloadURL: "http://example/binary"},
+				{Name: checksumName, BrowserDownloadURL: "http://example/checksum"},
+			},
+		}
+
+		urls, err := resolveAssetURL(rel)
+		if err != nil {
+			t.Fatalf("resolveAssetURL() error = %v", err)
+		}
+		if urls.BinaryURL != "http://example/binary" {
+			t.Fatalf("BinaryURL = %q", urls.BinaryURL)
+		}
+		if urls.ChecksumURL != "http://example/checksum" {
+			t.Fatalf("ChecksumURL = %q", urls.ChecksumURL)
+		}
+	})
+
+	t.Run("returns error when binary asset is missing", func(t *testing.T) {
+		rel := &release{
+			TagName: tag,
+			Assets: []asset{
+				{Name: checksumName, BrowserDownloadURL: "http://example/checksum"},
+			},
+		}
+
+		_, err := resolveAssetURL(rel)
+		if err == nil {
+			t.Fatal("resolveAssetURL() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), binaryName) {
+			t.Fatalf("error = %v, want binary name mention", err)
+		}
+	})
+
+	t.Run("returns error when checksum asset is missing", func(t *testing.T) {
+		rel := &release{
+			TagName: tag,
+			Assets: []asset{
+				{Name: binaryName, BrowserDownloadURL: "http://example/binary"},
+			},
+		}
+
+		_, err := resolveAssetURL(rel)
+		if err == nil {
+			t.Fatal("resolveAssetURL() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), checksumName) {
+			t.Fatalf("error = %v, want checksum name mention", err)
+		}
+	})
+}

--- a/internal/updater/replace.go
+++ b/internal/updater/replace.go
@@ -1,0 +1,79 @@
+package updater
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const sudoHint = "sudo mdc update"
+
+func replaceExecutable(data []byte, executablePath string) error {
+	if len(data) == 0 {
+		return fmt.Errorf("binary data is empty")
+	}
+
+	target, err := resolveExecutablePath(executablePath)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		return fmt.Errorf("stat executable %s: %w", target, err)
+	}
+	mode := info.Mode().Perm()
+
+	dir := filepath.Dir(target)
+	tmpFile, err := os.CreateTemp(dir, ".mdc-update-*")
+	if err != nil {
+		return permissionError(target, err)
+	}
+	tmpPath := tmpFile.Name()
+
+	cleanup := func() {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+	}
+	defer cleanup()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		return permissionError(target, err)
+	}
+	if err := tmpFile.Chmod(mode | 0111); err != nil {
+		return permissionError(target, err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return permissionError(target, err)
+	}
+
+	if err := os.Rename(tmpPath, target); err != nil {
+		return permissionError(target, err)
+	}
+
+	return nil
+}
+
+func resolveExecutablePath(executablePath string) (string, error) {
+	path := executablePath
+	if path == "" {
+		var err error
+		path, err = os.Executable()
+		if err != nil {
+			return "", fmt.Errorf("resolve executable path: %w", err)
+		}
+	}
+
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve symlinks for %s: %w", path, err)
+	}
+	return resolved, nil
+}
+
+func permissionError(target string, err error) error {
+	if os.IsPermission(err) {
+		return fmt.Errorf("cannot replace executable at %s: %w (try: %s)", target, err, sudoHint)
+	}
+	return fmt.Errorf("cannot replace executable at %s: %w", target, err)
+}

--- a/internal/updater/replace_test.go
+++ b/internal/updater/replace_test.go
@@ -1,0 +1,89 @@
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReplaceExecutable(t *testing.T) {
+	t.Run("replaces executable successfully", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "mdc")
+		original := []byte("original-binary")
+		if err := os.WriteFile(target, original, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		updated := []byte("updated-binary")
+		if err := replaceExecutable(updated, target); err != nil {
+			t.Fatalf("replaceExecutable() error = %v", err)
+		}
+
+		got, err := os.ReadFile(target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != string(updated) {
+			t.Fatalf("file content = %q, want %q", got, updated)
+		}
+
+		info, err := os.Stat(target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0111 == 0 {
+			t.Fatal("executable bit not preserved")
+		}
+	})
+
+	t.Run("replaces executable through symlink", func(t *testing.T) {
+		dir := t.TempDir()
+		realTarget := filepath.Join(dir, "mdc-real")
+		original := []byte("original-binary")
+		if err := os.WriteFile(realTarget, original, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		linkPath := filepath.Join(dir, "mdc-link")
+		if err := os.Symlink(realTarget, linkPath); err != nil {
+			t.Skip("symlinks not supported in this environment")
+		}
+
+		updated := []byte("updated-binary")
+		if err := replaceExecutable(updated, linkPath); err != nil {
+			t.Fatalf("replaceExecutable() error = %v", err)
+		}
+
+		got, err := os.ReadFile(realTarget)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != string(updated) {
+			t.Fatalf("real file content = %q, want %q", got, updated)
+		}
+	})
+
+	t.Run("permission error includes sudo hint", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "mdc")
+		if err := os.WriteFile(target, []byte("original"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(dir, 0555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			_ = os.Chmod(dir, 0755)
+		})
+
+		err := replaceExecutable([]byte("updated"), target)
+		if err == nil {
+			t.Fatal("replaceExecutable() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), sudoHint) {
+			t.Fatalf("error = %v, want %q hint", err, sudoHint)
+		}
+	})
+}

--- a/internal/updater/types.go
+++ b/internal/updater/types.go
@@ -1,0 +1,34 @@
+package updater
+
+import "net/http"
+
+type Options struct {
+	HTTPClient     *http.Client
+	APIBaseURL     string
+	ExecutablePath string
+	CheckPlatform  func() error
+}
+
+type Result struct {
+	Skipped bool
+	Version string
+	// LocalNewer is true when the locally-built version is ahead of the
+	// latest published release (a dev build), as opposed to being equal.
+	LocalNewer bool
+}
+
+type release struct {
+	TagName string  `json:"tag_name"`
+	Assets  []asset `json:"assets"`
+}
+
+type asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type assetURLs struct {
+	BinaryURL   string
+	ChecksumURL string
+	BinaryName  string
+}

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -1,0 +1,81 @@
+package updater
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"runtime"
+	"time"
+
+	"mdc/internal/version"
+)
+
+// defaultHTTPClient bounds every stage of the update download so a stalled
+// network cannot hang `mdc update` indefinitely: connect/TLS/response-header
+// timeouts catch a dead connection quickly, and the overall Timeout caps the
+// whole request (multi-MB binary included).
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 5 * time.Minute,
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 30 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   30 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+		},
+	}
+}
+
+func Update(opts Options) (Result, error) {
+	client := opts.HTTPClient
+	if client == nil {
+		client = defaultHTTPClient()
+	}
+
+	apiBase := opts.APIBaseURL
+	if apiBase == "" {
+		apiBase = defaultAPIBaseURL
+	}
+
+	checkPlatform := opts.CheckPlatform
+	if checkPlatform == nil {
+		checkPlatform = defaultCheckPlatform
+	}
+	if err := checkPlatform(); err != nil {
+		return Result{}, err
+	}
+
+	release, err := fetchLatestRelease(client, apiBase)
+	if err != nil {
+		return Result{}, err
+	}
+
+	needsUpdate, localNewer := compareVersion(version.Version, release.TagName)
+	if !needsUpdate {
+		return Result{Skipped: true, Version: release.TagName, LocalNewer: localNewer}, nil
+	}
+
+	urls, err := resolveAssetURL(release)
+	if err != nil {
+		return Result{}, err
+	}
+
+	binaryData, err := downloadAndVerify(client, urls)
+	if err != nil {
+		return Result{}, err
+	}
+
+	if err := replaceExecutable(binaryData, opts.ExecutablePath); err != nil {
+		return Result{}, err
+	}
+
+	return Result{Skipped: false, Version: release.TagName}, nil
+}
+
+func defaultCheckPlatform() error {
+	if runtime.GOOS != platformOS || runtime.GOARCH != platformArch {
+		return fmt.Errorf("mdc update is only supported on %s/%s (current: %s/%s)",
+			platformOS, platformArch, runtime.GOOS, runtime.GOARCH)
+	}
+	return nil
+}

--- a/internal/updater/update_test.go
+++ b/internal/updater/update_test.go
@@ -1,0 +1,188 @@
+package updater
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mdc/internal/version"
+)
+
+func TestUpdate(t *testing.T) {
+	tag := "v9.9.9"
+	binaryName := assetBinaryName(tag)
+	binaryData := []byte("updated-binary")
+	hash := sha256.Sum256(binaryData)
+	checksumContent := fmt.Sprintf("%s  %s\n", hex.EncodeToString(hash[:]), binaryName)
+
+	makeServer := func(rel release) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.URL.Path == latestReleaseAPIPath():
+				_ = json.NewEncoder(w).Encode(rel)
+			case strings.HasSuffix(r.URL.Path, "/binary"):
+				_, _ = w.Write(binaryData)
+			case strings.HasSuffix(r.URL.Path, ".sha256"):
+				_, _ = w.Write([]byte(checksumContent))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+	}
+
+	t.Run("skips when already up to date", func(t *testing.T) {
+		origVersion := version.Version
+		version.Version = "v2.0.3"
+		t.Cleanup(func() { version.Version = origVersion })
+
+		rel := release{
+			TagName: "v2.0.3",
+			Assets: []asset{
+				{Name: assetBinaryName("v2.0.3"), BrowserDownloadURL: "/binary"},
+				{Name: assetChecksumName(assetBinaryName("v2.0.3")), BrowserDownloadURL: "/checksum.sha256"},
+			},
+		}
+		server := makeServer(rel)
+		defer server.Close()
+
+		result, err := Update(Options{
+			HTTPClient:    server.Client(),
+			APIBaseURL:    server.URL,
+			CheckPlatform: func() error { return nil },
+		})
+		if err != nil {
+			t.Fatalf("Update() error = %v", err)
+		}
+		if !result.Skipped {
+			t.Fatal("expected skipped result")
+		}
+		if result.LocalNewer {
+			t.Fatal("expected LocalNewer false when versions are equal")
+		}
+	})
+
+	t.Run("skips and reports local newer when ahead of latest", func(t *testing.T) {
+		origVersion := version.Version
+		version.Version = "v2.1.0"
+		t.Cleanup(func() { version.Version = origVersion })
+
+		rel := release{
+			TagName: "v2.0.3",
+			Assets: []asset{
+				{Name: assetBinaryName("v2.0.3"), BrowserDownloadURL: "/binary"},
+				{Name: assetChecksumName(assetBinaryName("v2.0.3")), BrowserDownloadURL: "/checksum.sha256"},
+			},
+		}
+		server := makeServer(rel)
+		defer server.Close()
+
+		result, err := Update(Options{
+			HTTPClient:    server.Client(),
+			APIBaseURL:    server.URL,
+			CheckPlatform: func() error { return nil },
+		})
+		if err != nil {
+			t.Fatalf("Update() error = %v", err)
+		}
+		if !result.Skipped {
+			t.Fatal("expected skipped result")
+		}
+		if !result.LocalNewer {
+			t.Fatal("expected LocalNewer true when local version is ahead of latest")
+		}
+	})
+
+	t.Run("updates binary on newer release", func(t *testing.T) {
+		origVersion := version.Version
+		version.Version = "2.0.0"
+		t.Cleanup(func() { version.Version = origVersion })
+
+		dir := t.TempDir()
+		target := filepath.Join(dir, "mdc")
+		if err := os.WriteFile(target, []byte("old"), 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		rel := release{
+			TagName: tag,
+			Assets: []asset{
+				{Name: binaryName, BrowserDownloadURL: "/binary"},
+				{Name: assetChecksumName(binaryName), BrowserDownloadURL: "/checksum.sha256"},
+			},
+		}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.URL.Path == latestReleaseAPIPath():
+				_ = json.NewEncoder(w).Encode(rel)
+			case r.URL.Path == "/binary":
+				_, _ = w.Write(binaryData)
+			case r.URL.Path == "/checksum.sha256":
+				_, _ = w.Write([]byte(checksumContent))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		rel.Assets[0].BrowserDownloadURL = server.URL + "/binary"
+		rel.Assets[1].BrowserDownloadURL = server.URL + "/checksum.sha256"
+
+		result, err := Update(Options{
+			HTTPClient:     server.Client(),
+			APIBaseURL:     server.URL,
+			ExecutablePath: target,
+			CheckPlatform:  func() error { return nil },
+		})
+		if err != nil {
+			t.Fatalf("Update() error = %v", err)
+		}
+		if result.Skipped {
+			t.Fatal("expected update, got skipped")
+		}
+		if result.Version != tag {
+			t.Fatalf("Version = %q, want %q", result.Version, tag)
+		}
+
+		got, err := os.ReadFile(target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != string(binaryData) {
+			t.Fatalf("binary not replaced")
+		}
+	})
+
+	t.Run("returns error on unsupported platform", func(t *testing.T) {
+		_, err := Update(Options{
+			CheckPlatform: func() error {
+				return fmt.Errorf("mdc update is only supported on linux/amd64")
+			},
+		})
+		if err == nil {
+			t.Fatal("Update() expected error, got nil")
+		}
+	})
+
+	t.Run("returns error when API fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "fail", http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		_, err := Update(Options{
+			HTTPClient:    server.Client(),
+			APIBaseURL:    server.URL,
+			CheckPlatform: func() error { return nil },
+		})
+		if err == nil {
+			t.Fatal("Update() expected error, got nil")
+		}
+	})
+}

--- a/internal/updater/version.go
+++ b/internal/updater/version.go
@@ -1,0 +1,92 @@
+package updater
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// gitDescribeSuffix matches the "<commits>-g<hash>" trailer that
+// `git describe --tags` appends to a tag when HEAD is past it
+// (e.g. "v2.0.3-5-gabcdef" → suffix "-5-gabcdef").
+var gitDescribeSuffix = regexp.MustCompile(`-[0-9]+-g[0-9a-f]+$`)
+
+func DisplayVersion(v string) string {
+	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+// compareVersion reports how the locally-built `current` version relates to
+// the `latest` release tag.
+//
+//   - needsUpdate is true when `latest` is a newer release than `current`
+//     (or when the versions cannot be compared, so an explicit `mdc update`
+//     still proceeds).
+//   - localNewer is true when `current` is ahead of `latest` — e.g. a
+//     `make build-v` dev build with commits past the latest tag.
+//
+// git-describe metadata ("-<commits>-g<hash>" and/or "-dirty") is stripped
+// before comparing so a dev build ranks at or above its base tag instead of
+// being treated as a prerelease below it (which would cause a silent
+// downgrade to the older release binary).
+func compareVersion(current, latest string) (needsUpdate, localNewer bool) {
+	latestNorm := normalizeVersion(latest)
+	if !semver.IsValid(latestNorm) {
+		// The published tag is not semver; we cannot reason about it, but the
+		// user explicitly asked to update, so attempt it.
+		return true, false
+	}
+
+	base, ahead := baseReleaseTag(current)
+	currentNorm := normalizeVersion(base)
+	if !semver.IsValid(currentNorm) {
+		// Unidentifiable local build (e.g. "dev" or a bare commit hash);
+		// attempt the update the user asked for.
+		return true, false
+	}
+
+	switch cmp := semver.Compare(currentNorm, latestNorm); {
+	case cmp < 0:
+		return true, false
+	case cmp > 0:
+		return false, true
+	default:
+		// Base tag equals the latest release. A dev build with commits past
+		// the tag (or a dirty worktree) is ahead of the published release.
+		return false, ahead
+	}
+}
+
+// baseReleaseTag strips git-describe metadata from a version string,
+// returning the underlying release tag and whether the build is ahead of
+// that tag (extra commits and/or a dirty worktree). Genuine prerelease tags
+// such as "v2.1.0-rc1" are left untouched.
+func baseReleaseTag(v string) (base string, ahead bool) {
+	s := strings.TrimSpace(v)
+	if trimmed := strings.TrimSuffix(s, "-dirty"); trimmed != s {
+		s = trimmed
+		ahead = true
+	}
+	if loc := gitDescribeSuffix.FindStringIndex(s); loc != nil {
+		s = s[:loc[0]]
+		ahead = true
+	}
+	return s, ahead
+}
+
+func normalizeVersion(v string) string {
+	trimmed := strings.TrimSpace(v)
+	if trimmed == "" {
+		return ""
+	}
+	withoutV := strings.TrimPrefix(trimmed, "v")
+	return semver.Canonical("v" + withoutV)
+}
+
+func validateTagName(tag string) error {
+	if strings.TrimSpace(tag) == "" {
+		return fmt.Errorf("release tag_name is empty")
+	}
+	return nil
+}

--- a/internal/updater/version_test.go
+++ b/internal/updater/version_test.go
@@ -1,0 +1,115 @@
+package updater
+
+import (
+	"testing"
+)
+
+func TestCompareVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		current     string
+		latest      string
+		needsUpdate bool
+		localNewer  bool
+	}{
+		{
+			name:        "same version without v prefix",
+			current:     "2.0.3",
+			latest:      "v2.0.3",
+			needsUpdate: false,
+			localNewer:  false,
+		},
+		{
+			name:        "same version with v prefix",
+			current:     "v2.0.3",
+			latest:      "2.0.3",
+			needsUpdate: false,
+			localNewer:  false,
+		},
+		{
+			name:        "current is older",
+			current:     "2.0.2",
+			latest:      "v2.0.3",
+			needsUpdate: true,
+			localNewer:  false,
+		},
+		{
+			name:        "current is newer",
+			current:     "v2.1.0",
+			latest:      "v2.0.3",
+			needsUpdate: false,
+			localNewer:  true,
+		},
+		{
+			name:        "git-describe dev build past the latest tag is not a downgrade",
+			current:     "v2.0.3-5-gabcdef",
+			latest:      "v2.0.3",
+			needsUpdate: false,
+			localNewer:  true,
+		},
+		{
+			name:        "git-describe dev build older than latest still updates",
+			current:     "v2.0.3-5-gabcdef",
+			latest:      "v2.0.4",
+			needsUpdate: true,
+			localNewer:  false,
+		},
+		{
+			name:        "dirty build of the latest tag is not a downgrade",
+			current:     "v2.0.3-dirty",
+			latest:      "v2.0.3",
+			needsUpdate: false,
+			localNewer:  true,
+		},
+		{
+			name:        "genuine prerelease ranks below its release",
+			current:     "v2.0.3-rc1",
+			latest:      "v2.0.3",
+			needsUpdate: true,
+			localNewer:  false,
+		},
+		{
+			name:        "non-semver current forces update attempt",
+			current:     "dev",
+			latest:      "v2.0.3",
+			needsUpdate: true,
+			localNewer:  false,
+		},
+		{
+			name:        "non-semver latest forces update attempt",
+			current:     "2.0.3",
+			latest:      "snapshot",
+			needsUpdate: true,
+			localNewer:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			needsUpdate, localNewer := compareVersion(tt.current, tt.latest)
+			if needsUpdate != tt.needsUpdate || localNewer != tt.localNewer {
+				t.Fatalf("compareVersion(%q, %q) = (%v, %v), want (%v, %v)",
+					tt.current, tt.latest, needsUpdate, localNewer, tt.needsUpdate, tt.localNewer)
+			}
+		})
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "2.0.3", want: "v2.0.3"},
+		{input: "v2.0.3", want: "v2.0.3"},
+		{input: " v2.0.3 ", want: "v2.0.3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := normalizeVersion(tt.input); got != tt.want {
+				t.Fatalf("normalizeVersion(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

GitHub Releases から最新の Linux amd64 バイナリを取得して、実行中の `mdc` バイナリを置き換える `mdc update` コマンドを追加します（`internal/updater` + `cmd/update.go`）。

## 主な挙動

- **バージョン比較**: git-describe 形式の dev ビルド（例 `v2.0.3-5-gabcdef`, `v2.0.3-dirty`）はベースタグを抽出して比較し、タグより新しいローカルビルドを古いリリースで上書きしません。本物のプレリリース（`v2.1.0-rc1` 等）は従来どおり扱い、ローカルが最新より先行している場合は専用メッセージで通知します。
- **タイムアウト**: dial / TLS / レスポンスヘッダ（各30秒）＋全体（5分）のタイムアウト付き HTTP クライアントで取得し、ネットワーク停止時の無限ハングを防ぎます。`ProxyFromEnvironment` を尊重。
- **検証**: バイナリとチェックサムを並列取得し、SHA-256 で検証してから置換します。
- **エラー / 出力**: 失敗時は `logger.Error` で一度だけ出力して `os.Exit(1)`（他コマンドと同じ作法）。人間向けメッセージはコマンド色を付けない `logger.Info` で表示します。
- **アセット命名**: `.github/workflows/release.yml` を source of truth とし、`internal/updater/constants.go` に対応注記を追加。

## テスト

- バージョン比較（git-describe / dirty / プレリリース）、並列ダウンロード、SHA-256 検証、コマンド分岐、ロガーのユニットテストを同梱。
- `make check`（go vet + golangci-lint + 全テスト）green、`go test -race` クリーン。

## 対象プラットフォーム

現時点では **linux/amd64 限定**（それ以外は実行時に明示的なエラー）。
